### PR TITLE
Support for streaming backup and restoration

### DIFF
--- a/build.py
+++ b/build.py
@@ -704,7 +704,7 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                     elif package_type not in ['zip', 'tar'] and static or "static_" in arch:
                         logging.info("Skipping package type '{}' for static builds.".format(package_type))
                     else:
-                        fpm_command = "fpm {} --name {} -a {} -t {} --version {} --iteration {} -C {} -p {} ".format(
+                        fpm_command = "fpm {} --name {} -a {} -t {} --version {} --epoch 1000 --iteration {} -C {} -p {} ".format(
                             fpm_common_args,
                             name,
                             package_arch,

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -155,7 +155,7 @@ func (cmd *Command) runStdinTar() error {
 		} else if matches := shardRegex.FindStringSubmatch(hdr.Name); matches != nil {
 			// This is tar file containing contents of an individual shard. The 'backup -write-to-stdout' command does not
 			// generate these but this is presumably tar created manually from regular backup output
-			shardPath := filepath.Join(cmd.datadir, matches[1], matches[2], strings.Trim(matches[3], "0"))
+			shardPath := filepath.Join(cmd.datadir, matches[1], matches[2], strings.TrimLeft(matches[3], "0"))
 			cmd.StdoutLogger.Printf("Found shard tar %s, unpacking to %s", hdr.Name, shardPath)
 			if err = os.MkdirAll(shardPath, 0755); err != nil {
 				return err
@@ -164,7 +164,7 @@ func (cmd *Command) runStdinTar() error {
 				return err
 			}
 		} else if matches := tsmRegex.FindStringSubmatch(hdr.Name); matches != nil {
-			fileNameParts := append([]string{cmd.datadir, matches[1], matches[2], strings.Trim(matches[3], "0")}, strings.Split(matches[4], "/")...)
+			fileNameParts := append([]string{cmd.datadir, matches[1], matches[2], strings.TrimLeft(matches[3], "0")}, strings.Split(matches[4], "/")...)
 			restorePath := filepath.Join(fileNameParts...)
 			cmd.StdoutLogger.Printf("Found regular file %s, copying to target path %s", hdr.Name, restorePath)
 			if err = os.MkdirAll(filepath.Dir(restorePath), 0755); err != nil {
@@ -636,7 +636,7 @@ func (cmd *Command) unpackDatabase() error {
 	for _, fn := range backupFiles {
 		relativeName := strings.Replace(fn, prefix, "", 1)
 		if matches := tsmRegex.FindStringSubmatch(relativeName); matches != nil {
-			fileNameParts := append([]string{cmd.datadir, cmd.sourceDatabase, matches[1], strings.Trim(matches[2], "0")}, strings.Split(matches[3], pathSep)...)
+			fileNameParts := append([]string{cmd.datadir, cmd.sourceDatabase, matches[1], strings.TrimLeft(matches[2], "0")}, strings.Split(matches[3], pathSep)...)
 			restorePath := filepath.Join(fileNameParts...)
 			if err = cmd.copyFileIfRegular(fn, restorePath); err != nil {
 				return err
@@ -773,7 +773,7 @@ func (cmd *Command) unpackTar(tarFile string) error {
 		return fmt.Errorf("backup tarfile name incorrect format")
 	}
 
-	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.Trim(pathParts[2], "0"))
+	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.TrimLeft(pathParts[2], "0"))
 	os.MkdirAll(shardPath, 0755)
 
 	return tarstream.Restore(f, shardPath)

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -1360,7 +1360,7 @@ type TSDBStore interface {
 	WriteToShard(shardID uint64, points []models.Point) error
 
 	RestoreShard(id uint64, r io.Reader) error
-	BackupShard(id uint64, since time.Time, w io.Writer) error
+	BackupShard(id uint64, since time.Time, keepTarOpen bool, w io.Writer) error
 
 	DeleteDatabase(name string) error
 	DeleteMeasurement(database, name string) error

--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -13,7 +13,7 @@ import (
 
 // TSDBStoreMock is a mockable implementation of tsdb.Store.
 type TSDBStoreMock struct {
-	BackupShardFn             func(id uint64, since time.Time, w io.Writer) error
+	BackupShardFn             func(id uint64, since time.Time, keepTarOpen bool, w io.Writer) error
 	BackupSeriesFileFn        func(database string, w io.Writer) error
 	ExportShardFn             func(id uint64, ExportStart time.Time, ExportEnd time.Time, w io.Writer) error
 	CloseFn                   func() error
@@ -49,8 +49,8 @@ type TSDBStoreMock struct {
 	WriteToShardFn            func(shardID uint64, points []models.Point) error
 }
 
-func (s *TSDBStoreMock) BackupShard(id uint64, since time.Time, w io.Writer) error {
-	return s.BackupShardFn(id, since, w)
+func (s *TSDBStoreMock) BackupShard(id uint64, since time.Time, keepTarOpen bool, w io.Writer) error {
+	return s.BackupShardFn(id, since, keepTarOpen, w)
 }
 func (s *TSDBStoreMock) BackupSeriesFile(database string, w io.Writer) error {
 	return s.BackupSeriesFileFn(database, w)

--- a/pkg/tar/stream.go
+++ b/pkg/tar/stream.go
@@ -145,6 +145,11 @@ func extractFile(tr *tar.Reader, dir string) error {
 	}
 
 	destPath := filepath.Join(dir, relativePath)
+	return CreateFileFromTar(destPath, tr, hdr)
+}
+
+// CreateFileFromTar copies the contents of current file in the tar into local file via a temp file
+func CreateFileFromTar(destPath string, tr *tar.Reader, hdr *tar.Header) error {
 	tmp := destPath + ".tmp"
 
 	// Create new file on disk.

--- a/services/snapshotter/service.go
+++ b/services/snapshotter/service.go
@@ -40,7 +40,7 @@ type Service struct {
 	}
 
 	TSDBStore interface {
-		BackupShard(id uint64, since time.Time, w io.Writer) error
+		BackupShard(id uint64, since time.Time, keepTarOpen bool, w io.Writer) error
 		ExportShard(id uint64, ExportStart time.Time, ExportEnd time.Time, w io.Writer) error
 		Shard(id uint64) *tsdb.Shard
 		ShardRelativePath(id uint64) (string, error)
@@ -132,7 +132,7 @@ func (s *Service) handleConn(conn net.Conn) error {
 
 	switch RequestType(typ[0]) {
 	case RequestShardBackup:
-		if err := s.TSDBStore.BackupShard(r.ShardID, r.Since, conn); err != nil {
+		if err := s.TSDBStore.BackupShard(r.ShardID, r.Since, r.KeepTarOpen, conn); err != nil {
 			return err
 		}
 	case RequestShardExport:
@@ -455,6 +455,7 @@ type Request struct {
 	ExportStart            time.Time
 	ExportEnd              time.Time
 	UploadSize             int64
+	KeepTarOpen            bool
 }
 
 // Response contains the relative paths for all the shards on this server

--- a/services/snapshotter/service_test.go
+++ b/services/snapshotter/service_test.go
@@ -102,7 +102,7 @@ func TestSnapshotter_RequestShardBackup(t *testing.T) {
 	defer l.Close()
 
 	var tsdb internal.TSDBStoreMock
-	tsdb.BackupShardFn = func(id uint64, since time.Time, w io.Writer) error {
+	tsdb.BackupShardFn = func(id uint64, since time.Time, keepTarOpen bool, w io.Writer) error {
 		if id != 5 {
 			t.Errorf("unexpected shard id: got=%#v want=%#v", id, 5)
 		}

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -42,7 +42,7 @@ type Engine interface {
 	LoadMetadataIndex(shardID uint64, index Index) error
 
 	CreateSnapshot() (string, error)
-	Backup(w io.Writer, basePath string, since time.Time) error
+	Backup(w io.Writer, basePath string, since time.Time, keepTarOpen bool) error
 	Export(w io.Writer, basePath string, start time.Time, end time.Time) error
 	Restore(r io.Reader, basePath string) error
 	Import(r io.Reader, basePath string) error

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -905,7 +905,7 @@ func (e *Engine) Free() error {
 // that new TSM files will not be able to be created in this shard while the
 // backup is running. For shards that are still acively getting writes, this
 // could cause the WAL to backup, increasing memory usage and evenutally rejecting writes.
-func (e *Engine) Backup(w io.Writer, basePath string, since time.Time) error {
+func (e *Engine) Backup(w io.Writer, basePath string, since time.Time, keepTarOpen bool) error {
 	path, err := e.CreateSnapshot()
 	if err != nil {
 		return err
@@ -913,7 +913,7 @@ func (e *Engine) Backup(w io.Writer, basePath string, since time.Time) error {
 	// Remove the temporary snapshot dir
 	defer os.RemoveAll(path)
 
-	return intar.Stream(w, path, basePath, intar.SinceFilterTarFile(since))
+	return intar.Stream(w, path, basePath, intar.SinceFilterTarFile(since), keepTarOpen)
 }
 
 func (e *Engine) timeStampFilterTarFile(start, end time.Time) func(f os.FileInfo, shardRelativePath, fullPath string, tw *tar.Writer) error {
@@ -979,7 +979,7 @@ func (e *Engine) Export(w io.Writer, basePath string, start time.Time, end time.
 	// Remove the temporary snapshot dir
 	defer os.RemoveAll(path)
 
-	return intar.Stream(w, path, basePath, e.timeStampFilterTarFile(start, end))
+	return intar.Stream(w, path, basePath, e.timeStampFilterTarFile(start, end), false)
 }
 
 func (e *Engine) filterFileToBackup(r *TSMReader, fi os.FileInfo, shardRelativePath, fullPath string, start, end int64, tw *tar.Writer) error {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -260,7 +260,7 @@ func TestEngine_Backup(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	if err := e.Backup(b, "", time.Unix(0, 0)); err != nil {
+	if err := e.Backup(b, "", time.Unix(0, 0), false); err != nil {
 		t.Fatalf("failed to backup: %s", err.Error())
 	}
 
@@ -306,7 +306,7 @@ func TestEngine_Backup(t *testing.T) {
 	}
 
 	b = bytes.NewBuffer(nil)
-	if err := e.Backup(b, "", lastBackup); err != nil {
+	if err := e.Backup(b, "", lastBackup, false); err != nil {
 		t.Fatalf("failed to backup: %s", err.Error())
 	}
 
@@ -380,7 +380,7 @@ func TestEngine_Export(t *testing.T) {
 	}
 
 	var bkBuf bytes.Buffer
-	if err := e.Backup(&bkBuf, "", time.Unix(0, 0)); err != nil {
+	if err := e.Backup(&bkBuf, "", time.Unix(0, 0), false); err != nil {
 		t.Fatalf("failed to backup: %s", err.Error())
 	}
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1054,12 +1054,12 @@ func (s *Shard) expandSources(sources influxql.Sources) (influxql.Sources, error
 
 // Backup backs up the shard by creating a tar archive of all TSM files that
 // have been modified since the provided time. See Engine.Backup for more details.
-func (s *Shard) Backup(w io.Writer, basePath string, since time.Time) error {
+func (s *Shard) Backup(w io.Writer, basePath string, since time.Time, keepTarOpen bool) error {
 	engine, err := s.Engine()
 	if err != nil {
 		return err
 	}
-	return engine.Backup(w, basePath, since)
+	return engine.Backup(w, basePath, since, keepTarOpen)
 }
 
 func (s *Shard) Export(w io.Writer, basePath string, start time.Time, end time.Time) error {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1186,7 +1186,7 @@ func (s *Store) MeasurementsSketches(database string) (estimator.Sketch, estimat
 
 // BackupShard will get the shard and have the engine backup since the passed in
 // time to the writer.
-func (s *Store) BackupShard(id uint64, since time.Time, w io.Writer) error {
+func (s *Store) BackupShard(id uint64, since time.Time, keepTarOpen bool, w io.Writer) error {
 	shard := s.Shard(id)
 	if shard == nil {
 		return fmt.Errorf("shard %d doesn't exist on this server", id)
@@ -1197,7 +1197,7 @@ func (s *Store) BackupShard(id uint64, since time.Time, w io.Writer) error {
 		return err
 	}
 
-	return shard.Backup(w, path, since)
+	return shard.Backup(w, path, since, keepTarOpen)
 }
 
 func (s *Store) ExportShard(id uint64, start time.Time, end time.Time, w io.Writer) error {

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -511,7 +511,7 @@ func TestStore_BackupRestoreShard(t *testing.T) {
 
 		// Backup shard to a buffer.
 		var buf bytes.Buffer
-		if err := s0.BackupShard(100, time.Time{}, &buf); err != nil {
+		if err := s0.BackupShard(100, time.Time{}, false, &buf); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
This is a bit more convoluted than it could be as this pr implements support for cross restoration so that the streaming restoration can restore backups that were created by tarring a directory created with the non-streaming backup creation and the non-streaming restoration can restore backup that was created with streaming option. If this logic is upstreamed it might be more sensible to restrict restoration to only support the format generated by the corresponding backup mode to make the changes simpler.

Streaming backup supports backing up all databases in single command as well as restoring all databases in single command so it is very simple to fully back up and restore the entire data set.

As far as I could see there were no tests for the backup and restore commands at all so this pr doesn't introduce those either. All different combinations have been tested manually.