### PR TITLE
backup: Fix streaming backup of empty shards

### DIFF
--- a/pkg/tar/stream.go
+++ b/pkg/tar/stream.go
@@ -38,6 +38,14 @@ func Stream(w io.Writer, dir, relativePath string, writeFunc func(f os.FileInfo,
 
 		// Skip adding an entry for the root dir
 		if dir == path && f.IsDir() {
+			if keepTarOpen {
+				// It is possible the shard is otherwise empty. To avoid shard backup to be considered failed in that
+				// case always write an entry for the root directory. The restore command will ignore it (all directories
+				// are categorically ignored) but it causes some data to be returned.
+				// This is necessary as the tar generated from here is directly added as part of the backup tar and we
+				// cannot add end of tar zero bytes to signal some data was returned.
+				return writeFunc(f, relativePath, path, tw)
+			}
 			return nil
 		}
 


### PR DESCRIPTION
Previously streaming backup of empty shards always considered the shard
to have failed because no data was returned (which was assumed to mean
creating snapshot failed). To distinguish empty shard from failed
snapshot, always include directory entry of the temp directory that
contains the snapshot data in streamed backups. This makes the backups
always non-empty and restore code categorically ignores all directories
so this has no effect as far as restoration goes.