### PR TITLE
build.py: don't create man directories

### DIFF
--- a/build.py
+++ b/build.py
@@ -127,8 +127,7 @@ def create_package_fs(build_root):
              DATA_DIR[1:],
              SCRIPT_DIR[1:],
              CONFIG_DIR[1:],
-             LOGROTATE_DIR[1:],
-             MAN_DIR[1:] ]
+             LOGROTATE_DIR[1:] ]
     for d in dirs:
         os.makedirs(os.path.join(build_root, d))
         os.chmod(os.path.join(build_root, d), 0o755)


### PR DESCRIPTION
When this package is built in a mock environment, the /usr/share/man
directory is considered "owned" by the package and conflicts with the
upstream "filesystem" package.

To prevent this, don't create the man directory so there is nothing to
conflict.
