### PR TITLE
build.py: Fix aarch64 compilation

### DIFF
--- a/build.py
+++ b/build.py
@@ -516,6 +516,8 @@ def build(version=None,
         # Handle variations in architecture output
         if arch == "i386" or arch == "i686":
             arch = "386"
+        elif arch == "arm64":
+            pass
         elif "arm" in arch:
             arch = "arm"
         build_command += "GOOS={} GOARCH={} ".format(platform, arch)
@@ -526,7 +528,6 @@ def build(version=None,
             elif arch == "armhf" or arch == "arm":
                 build_command += "GOARM=6 "
             elif arch == "arm64":
-                # TODO(rossmcdonald) - Verify this is the correct setting for arm64
                 build_command += "GOARM=7 "
             else:
                 logging.error("Invalid ARM architecture specified: {}".format(arch))


### PR DESCRIPTION
Before:

```
influxd: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), static
ally linked, Go BuildID=wUbNjLkYnX9dlnggxLM5/g-IkuDoit7Mru43Jxb7v/QQgzthHmO7WfHC
eCKirH/E8BQAqhrH8vrT2q1kiC8, not stripped        
```

After:
```
influxd: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, Go BuildID=GGuPl6GdiZzxgbQ99mua/cOE3ZdFHTUOj9boFnp5m/1VQgwctE_5gV54Fz7Quv/_Ya93gWhN70zJCEeGIKX, not stripped
```