### PR TITLE
old version check could trigger version like go5.14.0

### DIFF
--- a/build.py
+++ b/build.py
@@ -540,7 +540,7 @@ def build(version=None,
             build_command += "-race "
         if len(tags) > 0:
             build_command += "-tags {} ".format(','.join(tags))
-        if "1.4" in get_go_version():
+        if "go1.4." in get_go_version():
             if static:
                 build_command += "-ldflags=\"-s -X main.version {} -X main.branch {} -X main.commit {}\" ".format(version,
                                                                                                                   get_current_branch(),


### PR DESCRIPTION
`build.py` thought it was using go v1.4 because the string test though 1.21.4 qualified. Test is now more reliable.