### PR TITLE
handler: add '/api/v1/aiven/read' endpoint

### DIFF
--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -20,7 +20,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     xmlto \
     docbook-xsl
 
-RUN gem install fpm
+RUN gem install ffi -f
+RUN gem install childprocess -f
+RUN gem install dotenv -v 2.7.6
+RUN gem install fpm -v 1.8.1
 
 # setup environment
 ENV GO_VERSION  1.13.8


### PR DESCRIPTION
This endpoint is an alternative to '/api/v1/prom/read' that differs in a few ways:
  - removed the hardcoded `"_field" == "value"` filter
  - return all numeric values (int/uint/bool)
  - include `__name__` field storing the measurement name
  - make matchers optional (return all by default)

The endpoint is intended to be used for migration from InfluxDB to Thanos.