### PR TITLE
prometheus: replace parentheses in metric names

### DIFF
--- a/prometheus/converters.go
+++ b/prometheus/converters.go
@@ -168,7 +168,7 @@ func AddMetricName(tags models.Tags) models.Tags {
 		t = append(t, tt)
 	}
 
-	r := strings.NewReplacer(".", "_", "-", "_")
+	r := strings.NewReplacer(".", "_", "-", "_", "(", "_", ")", "_")
 	name := r.Replace(measurement + "_" + field)
 	// TODO: omit `"_" + field` when `filed == "value"`
 	t = append([]models.Tag{


### PR DESCRIPTION
Parentheses are not valid characters for a metric name according to the Prometheus data model.
